### PR TITLE
Refactor setup module

### DIFF
--- a/src/features/setup/components/steps/VmDiscoveryStep.vue
+++ b/src/features/setup/components/steps/VmDiscoveryStep.vue
@@ -39,7 +39,7 @@ const toast = useToast()
 
 const isLoading = ref(true)
 const vms = ref<{ id: string; name: string; ip: string; state: string }[]>([])
-const editVm = ref<any>(null)
+const editVm = ref<{ id: string; name: string; ip: string; state: string } | null>(null)
 const setupStore = useSetupStore()
 const serverId = ref<string | null>(null);
 
@@ -75,10 +75,10 @@ setTimeout(() => {
     isLoading.value = false
 }, 2300)
 
-const openEdit = (vm: any) => {
+const openEdit = (vm: { id: string; name: string; ip: string; state: string }) => {
     editVm.value = { ...vm }
 }
-const handleSave = (updated: any) => {
+const handleSave = (updated: { id: string; name: string }) => {
     const i = vms.value.findIndex(vm => vm.id === updated.id)
     if (i !== -1) vms.value[i].name = updated.name
     editVm.value = null

--- a/src/features/setup/composables/useSetupFlow.ts
+++ b/src/features/setup/composables/useSetupFlow.ts
@@ -1,6 +1,6 @@
 import { computed } from "vue";
 import { useRouter, useRoute } from "vue-router";
-import { SetupStep } from "../types";
+import { SetupStep, SETUP_STEP_ORDER } from "../types";
 import { useSetupStore } from "../store";
 
 export const useSetupFlow = () => {
@@ -14,13 +14,7 @@ export const useSetupFlow = () => {
     );
   });
 
-  const stepOrder = [
-    SetupStep.WELCOME,
-    SetupStep.CREATE_ROOM,
-    SetupStep.CREATE_UPS,
-    SetupStep.CREATE_SERVER,
-    SetupStep.COMPLETE,
-  ];
+  const stepOrder = SETUP_STEP_ORDER;
 
   const currentStepIndex = computed(() => {
     return stepOrder.indexOf(currentStep.value);

--- a/src/features/setup/store.ts
+++ b/src/features/setup/store.ts
@@ -55,7 +55,6 @@ export const useSetupStore = defineStore("setup", () => {
         await router.push(`/setup/${status.currentStep}`);
       }
 
-      console.log("Setup status checked successfully");
     } catch (err: any) {
       error.value = err.message ?? "Erreur lors de la vérification du statut";
       console.error("Setup status error:", err);
@@ -79,7 +78,6 @@ export const useSetupStore = defineStore("setup", () => {
         break;
     }
 
-    console.log(`Saved data for step ${step}:`, data);
   };
 
   const getStepData = (step: SetupStep) => {
@@ -107,7 +105,6 @@ export const useSetupStore = defineStore("setup", () => {
     const currentIndex = steps.indexOf(setupStatus.value!.currentStep);
     const nextStep = steps[currentIndex + 1];
 
-    console.log("Current step:", setupStatus.value!.currentStep);
     if (nextStep) {
       await router.push(`/setup/${nextStep}`);
     }

--- a/src/features/setup/types.ts
+++ b/src/features/setup/types.ts
@@ -55,3 +55,11 @@ export interface SetupState {
   isLoading: boolean;
   error: string | null;
 }
+
+export const SETUP_STEP_ORDER: SetupStep[] = [
+  SetupStep.WELCOME,
+  SetupStep.CREATE_ROOM,
+  SetupStep.CREATE_UPS,
+  SetupStep.CREATE_SERVER,
+  SetupStep.COMPLETE,
+];

--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -1,0 +1,2 @@
+export const ipv4Regex = /^(?:\d{1,3}\.){3}\d{1,3}$/;
+export const ipv4Pattern = ipv4Regex.source;


### PR DESCRIPTION
## Summary
- centralize IPv4 regex in `src/utils/regex.ts`
- use the regex helper in setup steps
- expose `SETUP_STEP_ORDER` constant
- update `useSetupFlow` to rely on the exported order
- type server setup form and cleanup `any` usages
- remove leftover debug `console.log`

## Testing
- `pnpm build`