### PR TITLE
test/dashboard-api

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vue-tsc -b && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "@heroicons/vue": "^2.2.0",
@@ -28,12 +29,14 @@
     "@vitejs/plugin-vue": "^5.2.1",
     "@vue/tsconfig": "^0.7.0",
     "autoprefixer": "^10.4.21",
+    "jsdom": "^26.1.0",
     "postcss": "^8.5.3",
     "sass-embedded": "^1.89.2",
     "tailwindcss": "3.4.17",
     "typescript": "~5.7.2",
     "vite": "^6.2.6",
     "vite-tsconfig-paths": "^5.1.4",
+    "vitest": "^3.2.4",
     "vue-tsc": "^2.2.4"
   }
 }

--- a/src/features/dashboard/__tests__/api.spec.ts
+++ b/src/features/dashboard/__tests__/api.spec.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import axios from '@/services/api';
+import { dashboardApi } from '../api';
+
+// mock axios module
+vi.mock('@/services/api', () => ({
+  default: { get: vi.fn() },
+}));
+const mockedAxios = axios as unknown as { get: ReturnType<typeof vi.fn> };
+
+// simple localStorage mock
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => (key in store ? store[key] : null),
+    setItem: (key: string, value: string) => { store[key] = value; },
+    clear: () => { store = {}; },
+  };
+})();
+Object.defineProperty(global, 'localStorage', { value: localStorageMock });
+
+beforeEach(() => {
+  mockedAxios.get.mockReset();
+  localStorage.clear();
+});
+
+describe('dashboardApi.getFullStats', () => {
+  it('passes bearer token from localStorage', async () => {
+    mockedAxios.get.mockResolvedValue({ data: { ok: true } });
+    localStorage.setItem('token', 'abc');
+    await dashboardApi.getFullStats();
+    expect(mockedAxios.get).toHaveBeenCalledWith('/dashboard/full', {
+      headers: { Authorization: 'Bearer abc' },
+    });
+  });
+
+  it('uses null token when no token stored', async () => {
+    mockedAxios.get.mockResolvedValue({ data: {} });
+    await dashboardApi.getFullStats();
+    expect(mockedAxios.get).toHaveBeenCalledWith('/dashboard/full', {
+      headers: { Authorization: 'Bearer null' },
+    });
+  });
+});
+
+describe('dashboardApi.getServerCreations', () => {
+  it('returns mocked server creation data', async () => {
+    const data = await dashboardApi.getServerCreations();
+    expect(data).toHaveLength(6);
+    expect(data[0]).toEqual({ month: 'Jan', count: 3 });
+  });
+});
+
+describe('dashboardApi.getUPSLoad', () => {
+  it('returns mocked UPS load data', async () => {
+    const data = await dashboardApi.getUPSLoad();
+    expect(data).toHaveLength(6);
+    expect(data[0]).toEqual({ hour: '00h', load: 20 });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+import { fileURLToPath, URL } from 'node:url';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+  },
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- add Vitest config and dependencies
- implement unit tests for dashboard API

## Testing
- `pnpm test`