### PR TITLE
feat/userslist: replace mock users with paginated api

### DIFF
--- a/src/features/users/api.ts
+++ b/src/features/users/api.ts
@@ -1,9 +1,20 @@
 import axios from "@/services/api";
-import type { UserResponseDto, UserUpdateDto } from "./types";
+import type {
+  UserResponseDto,
+  UserUpdateDto,
+  UserListResponseDto,
+} from "./types";
 
-export const fetchUsers = () => {
-  console.log("Hello from users API");
-  return axios.get("/users");
+export const fetchUsers = async (
+  token: string,
+  page = 1,
+  limit = 10
+): Promise<UserListResponseDto> => {
+  const { data } = await axios.get<UserListResponseDto>("/user", {
+    params: { page, limit },
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  return data;
 };
 
 export const createUsers = (payload: any) => {

--- a/src/features/users/types.ts
+++ b/src/features/users/types.ts
@@ -21,3 +21,10 @@ export interface UserUpdateDto {
   email?: string;
   roleId?: string;
 }
+
+export interface UserListResponseDto {
+  items: UserResponseDto[];
+  totalItems: number;
+  totalPages: number;
+  currentPage: number;
+}

--- a/src/features/users/views/UserListView.vue
+++ b/src/features/users/views/UserListView.vue
@@ -28,12 +28,11 @@ const {
   loading,
   isMock,
   loadUsers,
+  totalItems,
 } = useUsers()
 const { loadRoles, roles } = useRoles()
 
-const paginatedUsers = computed(() =>
-  filteredUsers.value.slice((page.value - 1) * pageSize, page.value * pageSize)
-)
+const paginatedUsers = computed(() => filteredUsers.value)
 
 const openEditModal = (user: User) => {
   selectedUser.value = { ...user }
@@ -71,9 +70,10 @@ const copyEmail = (email: string) => {
 }
 
 onMounted(() => {
-  loadUsers()
+  loadUsers(page.value, pageSize)
   loadRoles()
 })
+watch(page, () => loadUsers(page.value, pageSize))
 watch([searchQuery, selectedRole], () => (page.value = 1))
 </script>
 
@@ -96,7 +96,7 @@ watch([searchQuery, selectedRole], () => (page.value = 1))
         <UserCard v-for="user in paginatedUsers" :key="user.id" :user="user" :roles="roles" @edit="openEditModal" />
       </div>
 
-      <PaginationControls :currentPage="page" :totalItems="filteredUsers.length" :pageSize="pageSize"
+      <PaginationControls :currentPage="page" :totalItems="totalItems" :pageSize="pageSize"
         @update:page="page = $event" />
     </template>
 


### PR DESCRIPTION
## Summary
- fetch paginated users from `/user`
- support metadata via new `UserListResponseDto`
- manage pagination in `useUsers` composable
- update `UserListView` to load server pages

## Testing
- `pnpm test`
- `pnpm build`