### PR TITLE
feat/i18n-complete

### DIFF
--- a/src/features/auth/components/LoginForm.vue
+++ b/src/features/auth/components/LoginForm.vue
@@ -93,7 +93,7 @@ async function handleLogin() {
     await store.loginUser({ identifier: identifier.value, password: password.value })
     emit('success')
   } catch (err: any) {
-    const message = err.message || 'Erreur inconnue'
+    const message = err.message || t('errors.unknown')
     error.value = message
     emit('error', message)
   } finally {

--- a/src/features/auth/components/RegisterForm.vue
+++ b/src/features/auth/components/RegisterForm.vue
@@ -168,12 +168,12 @@ async function handleRegister() {
   try {
     await store.registerUser(form.value);
     let token = store.token;
-    if (!token) throw new Error('Token non récupéré après l’inscription');
+    if (!token) throw new Error(t('errors.no_registration_token'));
     emit('success', { token });
   } catch (err: any) {
     console.error('RegisterForm error:', err);
     const msg = err.response?.data?.message;
-    const message = Array.isArray(msg) ? msg.join('\n') : msg || err.message || 'Une erreur est survenue.';
+    const message = Array.isArray(msg) ? msg.join('\n') : msg || err.message || t('errors.unknown');
     error.value = message;
     emit('error', message);
   } finally {

--- a/src/features/auth/store.ts
+++ b/src/features/auth/store.ts
@@ -10,6 +10,7 @@ import type {
 } from "./types";
 
 import { extractAxiosMessage } from "@/shared/utils/http";
+import { i18n } from '@/i18n';
 
 import {
   generate2FAQr,
@@ -59,7 +60,7 @@ export const useAuthStore = defineStore("auth", () => {
     } catch (err: any) {
       console.error("Login failed:", err);
       throw new Error(
-        err.response?.data?.message ?? err.message ?? "Erreur de connexion"
+        err.response?.data?.message ?? err.message ?? i18n.global.t('errors.connection')
       );
     }
   };

--- a/src/features/dashboard/__tests__/api.spec.ts
+++ b/src/features/dashboard/__tests__/api.spec.ts
@@ -47,7 +47,7 @@ describe('dashboardApi.getServerCreations', () => {
   it('returns mocked server creation data', async () => {
     const data = await dashboardApi.getServerCreations();
     expect(data).toHaveLength(6);
-    expect(data[0]).toEqual({ month: 'Jan', count: 3 });
+    expect(data[0]).toEqual({ month: 'jan', count: 3 });
   });
 });
 

--- a/src/features/dashboard/api.ts
+++ b/src/features/dashboard/api.ts
@@ -39,12 +39,12 @@ export const dashboardApi = {
    */
   getServerCreations: async (): Promise<ServerCreationStat[]> => {
     return [
-      { month: "Jan", count: 3 },
-      { month: "Fév", count: 5 },
-      { month: "Mar", count: 2 },
-      { month: "Avr", count: 6 },
-      { month: "Mai", count: 4 },
-      { month: "Juin", count: 5 },
+      { month: "jan", count: 3 },
+      { month: "feb", count: 5 },
+      { month: "mar", count: 2 },
+      { month: "apr", count: 6 },
+      { month: "may", count: 4 },
+      { month: "jun", count: 5 },
     ];
   },
 

--- a/src/features/dashboard/components/DashboardCharts.vue
+++ b/src/features/dashboard/components/DashboardCharts.vue
@@ -52,7 +52,7 @@ function renderCharts() {
     serverChartInstance = new Chart(serverChart.value, {
       type: "bar",
       data: {
-        labels: props.serverData.map((s) => s.month),
+        labels: props.serverData.map((s) => t(`months.${s.month}`)),
         datasets: [
           {
             label: t('dashboard.server_creations_label'),

--- a/src/features/rooms/views/RoomDetails.vue
+++ b/src/features/rooms/views/RoomDetails.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, onMounted } from "vue";
 import { useRoute, useRouter } from "vue-router";
+import { useI18n } from 'vue-i18n';
 import type { Room } from "../types";
 import type { Server } from "../../servers/types";
 import { type Ups, UpsState} from "../../ups/types";
@@ -9,6 +10,7 @@ import UpsCard from "../../ups/components/UpsCard.vue";
 
 const route = useRoute();
 const router = useRouter();
+const { t } = useI18n();
 
 const roomId = route.params.id as string;
 const room = ref<Room | null>(null);
@@ -117,12 +119,12 @@ const getMockUps = (roomId: string): Ups[] => [
             d="M15 19l-7-7 7-7"
           />
         </svg>
-        Retour
+        {{ t('common.back') }}
       </button>
     </div>
 
     <div v-if="loading" class="flex justify-center items-center h-64">
-      <p class="text-neutral-dark text-lg animate-pulse">Chargement...</p>
+      <p class="text-neutral-dark text-lg animate-pulse">{{ t('rooms.loading') }}</p>
     </div>
 
     <div v-else-if="room" class="space-y-10">
@@ -130,7 +132,7 @@ const getMockUps = (roomId: string): Ups[] => [
         <h1 class="text-4xl font-extrabold text-neutral-darker">
           {{ room.name }}
         </h1>
-        <p class="text-sm text-neutral-dark">ID de la salle : {{ room.id }}</p>
+        <p class="text-sm text-neutral-dark">{{ t('rooms.id_label') }} {{ room.id }}</p>
       </div>
 
       <section class="space-y-6">
@@ -150,7 +152,7 @@ const getMockUps = (roomId: string): Ups[] => [
           />
         </div>
         <p v-else class="text-neutral-dark italic">
-          Aucun serveur dans cette salle.
+          {{ t('rooms.no_server_room') }}
         </p>
       </section>
 
@@ -171,7 +173,7 @@ const getMockUps = (roomId: string): Ups[] => [
           />
         </div>
         <p v-else class="text-neutral-dark italic">
-          Aucun onduleur dans cette salle.
+          {{ t('rooms.no_ups_room') }}
         </p>
       </section>
     </div>

--- a/src/features/servers/views/ServerDetailsView.vue
+++ b/src/features/servers/views/ServerDetailsView.vue
@@ -71,9 +71,9 @@ const handlePing = () => {
 <template>
   <div class="p-6 max-w-5xl mx-auto space-y-6">
     <nav class="text-sm text-neutral-dark">
-      <span class="text-neutral-dark/60">Infrastructure /</span>
+      <span class="text-neutral-dark/60">{{ t('common.infrastructure') }} /</span>
       <router-link to="/servers" class="text-primary hover:underline"
-        >Serveurs</router-link
+        >{{ t('nav.servers') }}</router-link
       >
       <span class="mx-1">/</span>
       <span class="font-medium text-neutral-darker">{{

--- a/src/features/setup/components/steps/CreateServerStep.vue
+++ b/src/features/setup/components/steps/CreateServerStep.vue
@@ -73,12 +73,12 @@
 
             <div>
                 <h3 class="text-lg font-semibold text-neutral-darker mb-4 border-b border-neutral-200 pb-2">
-                    Informations générales
+                    {{ t('setup_server.general_title') }}
                 </h3>
                 <div class="mb-6">
                     <label for="name" class="block font-medium text-neutral-darker flex items-center gap-2 mb-1">
                         <Server :size="18" class="text-primary" />
-                        Nom du serveur
+                        {{ t('setup_server.name_label') }}
                     </label>
                     <input id="name" v-model="form.name" type="text"
                         class="block w-full border border-neutral-300 rounded-lg px-3 py-2 text-base focus:ring-2 focus:ring-primary focus:border-primary transition"
@@ -88,25 +88,25 @@
                     <div>
                         <label for="type" class="block font-medium text-neutral-darker flex items-center gap-2 mb-1">
                             <Cpu :size="18" class="text-primary" />
-                            Type de serveur
+                            {{ t('setup_server.type_label') }}
                         </label>
                         <select id="type" v-model="form.type"
                             class="block w-full border border-neutral-300 rounded-lg px-3 py-2 text-base bg-white focus:ring-2 focus:ring-primary focus:border-primary transition"
                             required>
-                            <option value="physical">Physique</option>
-                            <option value="virtual">Virtuel</option>
+                            <option value="physical">{{ t('setup_server.type_physical') }}</option>
+                            <option value="virtual">{{ t('setup_server.type_virtual') }}</option>
                         </select>
                     </div>
                     <div>
                         <label for="state" class="block font-medium text-neutral-darker flex items-center gap-2 mb-1">
                             <Power :size="18" class="text-primary" />
-                            État initial
+                            {{ t('setup_server.state_label') }}
                         </label>
                         <select id="state" v-model="form.state"
                             class="block w-full border border-neutral-300 rounded-lg px-3 py-2 text-base bg-white focus:ring-2 focus:ring-primary focus:border-primary transition"
                             required>
-                            <option value="active">Allumé</option>
-                            <option value="inactive">Éteint</option>
+                            <option value="active">{{ t('setup_server.state_on') }}</option>
+                            <option value="inactive">{{ t('setup_server.state_off') }}</option>
                         </select>
                     </div>
                 </div>

--- a/src/features/setup/components/steps/WelcomeStep.vue
+++ b/src/features/setup/components/steps/WelcomeStep.vue
@@ -50,7 +50,7 @@
       type="button"
       @click="handleWelcomeNext"
       class="inline-flex items-center gap-2 bg-primary text-white font-semibold rounded-2xl px-8 py-3 shadow-md hover:bg-primary-dark focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 transition active:scale-95"
-      aria-label="Passer à l'étape suivante : créer une salle serveur"
+      :aria-label="t('setup.next_step_aria')"
     >
       <Building2 :size="20" />
       {{ t('setup.start_button') }}

--- a/src/features/users/composables/useUsers.ts
+++ b/src/features/users/composables/useUsers.ts
@@ -1,4 +1,5 @@
 import { ref, computed } from "vue";
+import { i18n } from '@/i18n';
 import type {
   User,
   UserResponseDto,
@@ -31,7 +32,7 @@ export const useUsers = () => {
     isMock.value = false;
     try {
       const token = authStore.token ?? localStorage.getItem("token");
-      if (!token) throw new Error("Aucun token JWT trouvé");
+      if (!token) throw new Error(i18n.global.t('errors.no_token'));
 
       const data: UserListResponseDto = await fetchUsers(token, page, limit);
       users.value = data.items;
@@ -53,7 +54,7 @@ export const useUsers = () => {
     updated: UserUpdateDto
   ): Promise<UserResponseDto> => {
     const token = authStore.token ?? localStorage.getItem("token");
-    if (!token) throw new Error("Aucun token JWT trouvé");
+    if (!token) throw new Error(i18n.global.t('errors.no_token'));
 
     const response = await updateCurrentUserAPI(updated, token);
     authStore.currentUser = response;
@@ -72,14 +73,14 @@ export const useUsers = () => {
 
   const resetCurrentUserPassword = async (newPassword: string) => {
     const token = authStore.token ?? localStorage.getItem("token");
-    if (!token) throw new Error("Aucun token JWT trouvé");
+    if (!token) throw new Error(i18n.global.t('errors.no_token'));
 
     await apiResetPwd(newPassword, token);
   };
 
   const deleteMeAccount = async () => {
     const token = authStore.token ?? localStorage.getItem("token");
-    if (!token) throw new Error("Aucun token JWT trouvé");
+    if (!token) throw new Error(i18n.global.t('errors.no_token'));
 
     await deleteCurrentUser(token);
   };

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -61,7 +61,8 @@
     "step_add_ups": "Add UPS",
     "step_add_server": "Add server",
     "step_complete": "Complete",
-    "skip_confirm": "Are you sure you want to skip guided setup?"
+    "skip_confirm": "Are you sure you want to skip guided setup?",
+    "next_step_aria": "Go to next step: create a server room"
   },
   "rooms": {
     "list_title": "Room list",
@@ -76,7 +77,10 @@
     "create_button": "Create room",
     "creating": "Creating...",
     "view_details": "View details →",
-    "load_error": "Error loading rooms"
+    "load_error": "Error loading rooms",
+    "id_label": "Room ID:",
+    "no_server_room": "No server in this room.",
+    "no_ups_room": "No UPS in this room."
   },
   "pagination": {
     "page": "Page",
@@ -436,6 +440,14 @@
   "setup_server": {
     "room_label": "Room",
     "ups_label": "Associated UPS",
+    "general_title": "General information",
+    "name_label": "Server name",
+    "type_label": "Server type",
+    "state_label": "Initial state",
+    "type_physical": "Physical",
+    "type_virtual": "Virtual",
+    "state_on": "On",
+    "state_off": "Off",
     "title": "Add your server",
     "description": "Configure a server to start monitoring your infrastructure.",
     "submit": "Save and continue",
@@ -509,5 +521,23 @@
     "step_error": "Error while completing step",
     "progress_error": "Error while retrieving progress"
   },
-  "search": "Search"
+  "search": "Search",
+  "common": {
+    "infrastructure": "Infrastructure",
+    "back": "Back"
+  },
+  "errors": {
+    "unknown": "Unknown error",
+    "connection": "Connection error",
+    "no_token": "No JWT token found",
+    "no_registration_token": "Registration token not retrieved"
+  },
+  "months": {
+    "jan": "Jan",
+    "feb": "Feb",
+    "mar": "Mar",
+    "apr": "Apr",
+    "may": "May",
+    "jun": "Jun"
+  }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -61,7 +61,8 @@
     "step_add_ups": "Ajouter un onduleur",
     "step_add_server": "Ajouter un serveur",
     "step_complete": "Terminé",
-    "skip_confirm": "Êtes-vous sûr de vouloir passer la configuration guidée ?"
+    "skip_confirm": "Êtes-vous sûr de vouloir passer la configuration guidée ?",
+    "next_step_aria": "Passer à l'étape suivante : créer une salle serveur"
   },
   "rooms": {
     "list_title": "Liste des salles",
@@ -76,7 +77,10 @@
     "create_button": "Créer la salle",
     "creating": "Création...",
     "view_details": "Voir les détails",
-    "load_error": "Erreur de chargement des salles"
+    "load_error": "Erreur de chargement des salles",
+    "id_label": "ID de la salle :",
+    "no_server_room": "Aucun serveur dans cette salle.",
+    "no_ups_room": "Aucun onduleur dans cette salle."
   },
   "pagination": {
     "page": "Page",
@@ -429,6 +433,14 @@
   "setup_server": {
     "room_label": "Salle",
     "ups_label": "Onduleur associé",
+    "general_title": "Informations générales",
+    "name_label": "Nom du serveur",
+    "type_label": "Type de serveur",
+    "state_label": "État initial",
+    "type_physical": "Physique",
+    "type_virtual": "Virtuel",
+    "state_on": "Allumé",
+    "state_off": "Éteint",
     "title": "Ajoute ton serveur",
     "description": "Configure un serveur pour commencer à superviser ton infra.",
     "submit": "Valider et passer à l'étape suivante",
@@ -502,5 +514,23 @@
     "step_error": "Erreur lors de la complétion de l'étape",
     "progress_error": "Erreur lors de la récupération de la progression"
   },
-  "search": "Recherche"
+  "search": "Recherche",
+  "common": {
+    "infrastructure": "Infrastructure",
+    "back": "Retour"
+  },
+  "errors": {
+    "unknown": "Erreur inconnue",
+    "connection": "Erreur de connexion",
+    "no_token": "Aucun token JWT trouvé",
+    "no_registration_token": "Token non récupéré après l’inscription"
+  },
+  "months": {
+    "jan": "Jan",
+    "feb": "Fév",
+    "mar": "Mar",
+    "apr": "Avr",
+    "may": "Mai",
+    "jun": "Juin"
+  }
 }

--- a/src/shared/utils/http.ts
+++ b/src/shared/utils/http.ts
@@ -1,4 +1,6 @@
+import { i18n } from '@/i18n'
+
 export const extractAxiosMessage = (err: any): string =>
     err?.response?.data?.message ??
     err?.response?.data?.error ??
-    'Une erreur inconnue est survenue.';
+    i18n.global.t('errors.unknown');


### PR DESCRIPTION
## Summary
- finish translation coverage for dashboard charts
- internationalize auth error messages
- add i18n strings for room and server details
- localize server creation step labels
- provide common error/month names in locale files

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_b_685c266fdc94832d975f5dd16cdc7b31