### PR TITLE
feat/history: improve filters

### DIFF
--- a/src/features/history/__tests__/api.spec.ts
+++ b/src/features/history/__tests__/api.spec.ts
@@ -61,6 +61,23 @@ describe('historyApi.getList', () => {
     })
   })
 
+  it('ignores empty filter values', async () => {
+    mockedAxios.get.mockResolvedValue({ data: { items: [] } })
+    await historyApi.getList(1, 10, {
+      entity: undefined,
+      action: HistoryAction.Delete,
+      userId: '',
+    })
+    expect(mockedAxios.get).toHaveBeenCalledWith('/history', {
+      params: {
+        page: 1,
+        limit: 10,
+        action: 'DELETE',
+      },
+      headers: { Authorization: 'Bearer null' },
+    })
+  })
+
   it('uses defaults when no params', async () => {
     mockedAxios.get.mockResolvedValue({ data: { items: [] } })
     await historyApi.getList()

--- a/src/features/history/api.ts
+++ b/src/features/history/api.ts
@@ -7,14 +7,21 @@ const getAuthHeaders = () => ({
   },
 })
 
+const sanitizeFilters = (filters: HistoryFilter) => {
+  return Object.fromEntries(
+    Object.entries(filters).filter(([, v]) => v !== undefined && v !== '')
+  )
+}
+
 export const historyApi = {
   getList: async (
     page = 1,
     limit = 10,
     filters: HistoryFilter = {}
   ): Promise<HistoryListResponseDto> => {
+    const params = { page, limit, ...sanitizeFilters(filters) }
     const { data } = await api.get<HistoryListResponseDto>('/history', {
-      params: { page, limit, ...filters },
+      params,
       ...getAuthHeaders(),
     })
     return data

--- a/src/features/history/store.ts
+++ b/src/features/history/store.ts
@@ -29,5 +29,25 @@ export const useHistoryStore = defineStore('history', () => {
     Object.assign(filters, f)
   }
 
-  return { events, loading, totalItems, totalPages, currentPage, filters, fetchHistory, setFilters }
+  const resetFilters = () => {
+    Object.assign(filters, {
+      entity: undefined,
+      action: undefined,
+      userId: undefined,
+      from: undefined,
+      to: undefined,
+    })
+  }
+
+  return {
+    events,
+    loading,
+    totalItems,
+    totalPages,
+    currentPage,
+    filters,
+    fetchHistory,
+    setFilters,
+    resetFilters,
+  }
 })

--- a/src/features/history/views/HistoryListView.vue
+++ b/src/features/history/views/HistoryListView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted } from 'vue'
+import { onMounted, watch } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useHistoryStore } from '../store'
 import PaginationControls from '@/features/users/components/PaginationControls.vue'
@@ -10,12 +10,20 @@ const { t } = useI18n()
 const historyStore = useHistoryStore()
 const { events, loading, totalItems, currentPage, filters } =
   storeToRefs(historyStore)
-const { fetchHistory, setFilters } = historyStore
+const { fetchHistory, setFilters, resetFilters } = historyStore
 const pageSize = 10
 const entities = Object.values(HistoryEntity)
 const actions = Object.values(HistoryAction)
 
 onMounted(() => fetchHistory())
+
+watch(
+  filters,
+  () => {
+    fetchHistory(1, pageSize)
+  },
+  { deep: true }
+)
 
 const applyFilters = () => {
   fetchHistory(1, pageSize)
@@ -48,6 +56,9 @@ const formatDate = (d: string) => new Date(d).toLocaleString()
           :aria-label="t('administration.history_details.filters.to')" />
         <button class="px-4 py-1 bg-primary text-white rounded" @click="applyFilters">
           {{ t('administration.history_details.filters.apply') }}
+        </button>
+        <button class="px-4 py-1 bg-neutral-light rounded" @click="resetFilters">
+          {{ t('common.reset') }}
         </button>
       </div>
 


### PR DESCRIPTION
## Summary
- sanitize history filters before API calls
- expose `resetFilters` and watch filter changes
- auto-refresh list when filters update
- add regression tests for filter cleanup

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_b_6860fc78f32c832db41a807d2316fe6c