### PR TITLE
feat/changelog: support paginated releases

### DIFF
--- a/src/features/changelog/__tests__/api.spec.ts
+++ b/src/features/changelog/__tests__/api.spec.ts
@@ -13,17 +13,27 @@ beforeEach(() => {
 });
 
 describe('changelogApi.fetchReleases', () => {
-  it('calls /releases endpoint', async () => {
-    mockedAxios.get.mockResolvedValue({ data: { frontend: [], backend: [] } });
+  it('calls /releases endpoint with params', async () => {
+    mockedAxios.get.mockResolvedValue({ data: { frontend: {}, backend: {} } });
+    await changelogApi.fetchReleases(2, 5);
+    expect(mockedAxios.get).toHaveBeenCalledWith('/releases', {
+      params: { page: 2, limit: 5 },
+    });
+  });
+
+  it('uses defaults', async () => {
+    mockedAxios.get.mockResolvedValue({ data: { frontend: {}, backend: {} } });
     await changelogApi.fetchReleases();
-    expect(mockedAxios.get).toHaveBeenCalledWith('/releases');
+    expect(mockedAxios.get).toHaveBeenCalledWith('/releases', {
+      params: { page: 1, limit: 10 },
+    });
   });
 });
 
 describe('getMockChangelog', () => {
   it('returns mock data', () => {
     const data = getMockChangelog();
-    expect(data.frontend.length).toBeGreaterThan(0);
-    expect(data.backend.length).toBeGreaterThan(0);
+    expect(data.frontend.items.length).toBeGreaterThan(0);
+    expect(data.backend.items.length).toBeGreaterThan(0);
   });
 });

--- a/src/features/changelog/api.ts
+++ b/src/features/changelog/api.ts
@@ -3,8 +3,13 @@ import type { ChangelogResponse } from './types';
 
 export const changelogApi = {
   /** Fetch releases for frontend and backend */
-  fetchReleases: async (): Promise<ChangelogResponse> => {
-    const { data } = await axios.get<ChangelogResponse>('/releases');
+  fetchReleases: async (
+    page = 1,
+    limit = 10,
+  ): Promise<ChangelogResponse> => {
+    const { data } = await axios.get<ChangelogResponse>('/releases', {
+      params: { page, limit },
+    });
     return data;
   },
 };

--- a/src/features/changelog/components/ReleaseCard.vue
+++ b/src/features/changelog/components/ReleaseCard.vue
@@ -13,12 +13,12 @@ const rendered = computed(() => md.render(props.release.body));
   <div class="bg-white border rounded-xl shadow p-4 space-y-2">
     <h3 class="text-lg font-semibold">{{ release.name }}</h3>
     <p class="text-sm text-neutral-dark">
-      {{ new Date(release.published_at).toLocaleDateString() }}
+      {{ new Date(release.publishedAt).toLocaleDateString() }}
       <span v-if="release.author"> — {{ release.author }}</span>
     </p>
     <div v-html="rendered" class="prose max-w-none text-sm"></div>
     <a
-      :href="release.html_url"
+      :href="release.htmlUrl"
       target="_blank"
       class="text-primary hover:underline text-sm block"
     >

--- a/src/features/changelog/components/ReleaseList.vue
+++ b/src/features/changelog/components/ReleaseList.vue
@@ -9,7 +9,7 @@ defineProps<{ releases: Release[] }>();
   <div class="space-y-4">
     <ReleaseCard
       v-for="rel in releases"
-      :key="rel.tag_name"
+      :key="rel.tagName"
       :release="rel"
     />
   </div>

--- a/src/features/changelog/mock.ts
+++ b/src/features/changelog/mock.ts
@@ -1,24 +1,34 @@
 import type { ChangelogResponse } from './types';
 
 export const getMockChangelog = (): ChangelogResponse => ({
-  frontend: [
-    {
-      name: 'Frontend 0.1.0',
-      tag_name: 'v0.1.0',
-      published_at: new Date('2024-05-20').toISOString(),
-      author: 'Alice',
-      body: '# Added\n- Initial release',
-      html_url: 'https://github.com/example/frontend/releases/v0.1.0',
-    },
-  ],
-  backend: [
-    {
-      name: 'Backend 0.1.0',
-      tag_name: 'v0.1.0',
-      published_at: new Date('2024-05-15').toISOString(),
-      author: 'Bob',
-      body: '# Added\n- Initial release',
-      html_url: 'https://github.com/example/backend/releases/v0.1.0',
-    },
-  ],
+  frontend: {
+    items: [
+      {
+        name: 'Frontend 0.1.0',
+        tagName: 'v0.1.0',
+        publishedAt: new Date('2024-05-20').toISOString(),
+        author: 'Alice',
+        body: '# Added\n- Initial release',
+        htmlUrl: 'https://github.com/example/frontend/releases/v0.1.0',
+      },
+    ],
+    totalItems: 1,
+    totalPages: 1,
+    currentPage: 1,
+  },
+  backend: {
+    items: [
+      {
+        name: 'Backend 0.1.0',
+        tagName: 'v0.1.0',
+        publishedAt: new Date('2024-05-15').toISOString(),
+        author: 'Bob',
+        body: '# Added\n- Initial release',
+        htmlUrl: 'https://github.com/example/backend/releases/v0.1.0',
+      },
+    ],
+    totalItems: 1,
+    totalPages: 1,
+    currentPage: 1,
+  },
 });

--- a/src/features/changelog/types.ts
+++ b/src/features/changelog/types.ts
@@ -1,13 +1,20 @@
 export interface Release {
   name: string;
-  tag_name: string;
-  published_at: string;
-  author?: string;
+  tagName: string;
+  publishedAt: string;
+  author?: string | null;
   body: string;
-  html_url: string;
+  htmlUrl: string;
+}
+
+export interface ReleaseListResponseDto {
+  items: Release[];
+  totalItems: number;
+  totalPages: number;
+  currentPage: number;
 }
 
 export interface ChangelogResponse {
-  frontend: Release[];
-  backend: Release[];
+  frontend: ReleaseListResponseDto;
+  backend: ReleaseListResponseDto;
 }

--- a/src/features/changelog/views/ChangelogView.vue
+++ b/src/features/changelog/views/ChangelogView.vue
@@ -1,24 +1,36 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue';
+import { ref, onMounted, watch } from 'vue';
 import ReleaseList from '../components/ReleaseList.vue';
 import { changelogApi } from '../api';
 import { getMockChangelog } from '../mock';
 import type { Release } from '../types';
+import PaginationControls from '@/features/users/components/PaginationControls.vue';
 
 const frontend = ref<Release[]>([]);
 const backend = ref<Release[]>([]);
 const loading = ref(true);
 const error = ref('');
+const page = ref(1);
+const pageSize = 5;
+const totalItems = ref(0);
 
 const fetchData = async () => {
   try {
-    const data = await changelogApi.fetchReleases();
-    frontend.value = data.frontend;
-    backend.value = data.backend;
+    const data = await changelogApi.fetchReleases(page.value, pageSize);
+    frontend.value = data.frontend.items;
+    backend.value = data.backend.items;
+    totalItems.value = Math.max(
+      data.frontend.totalItems,
+      data.backend.totalItems,
+    );
   } catch {
     const mock = getMockChangelog();
-    frontend.value = mock.frontend;
-    backend.value = mock.backend;
+    frontend.value = mock.frontend.items;
+    backend.value = mock.backend.items;
+    totalItems.value = Math.max(
+      mock.frontend.totalItems,
+      mock.backend.totalItems,
+    );
     error.value = 'Failed to fetch releases';
   } finally {
     loading.value = false;
@@ -26,6 +38,7 @@ const fetchData = async () => {
 };
 
 onMounted(fetchData);
+watch(page, fetchData);
 </script>
 
 <template>
@@ -41,6 +54,12 @@ onMounted(fetchData);
         <h2 class="text-xl font-semibold mb-2">Backend</h2>
         <ReleaseList :releases="backend" />
       </div>
+      <PaginationControls
+        :current-page="page"
+        :total-items="totalItems"
+        :page-size="pageSize"
+        @update:page="(p) => (page.value = p)"
+      />
     </div>
     <p v-if="error" class="text-red-500">{{ error }}</p>
   </div>


### PR DESCRIPTION
## Summary
- update types to match paginated backend data
- add page and limit params in changelog API
- adjust changelog components and view for pagination
- update mock data and tests

## Testing
- `pnpm test`