### PR TITLE
feat: introduce reusable ErrorAlert component

### DIFF
--- a/src/features/roles/components/AssignUsersModal.vue
+++ b/src/features/roles/components/AssignUsersModal.vue
@@ -134,18 +134,7 @@
           </div>
         </div>
 
-        <div v-if="props.error" class="mt-4 p-4 bg-red-50 border border-red-200 rounded-md">
-          <div class="flex">
-            <div class="flex-shrink-0">
-              <ExclamationTriangleIcon class="h-5 w-5 text-red-400" />
-            </div>
-            <div class="ml-3">
-              <p class="text-sm text-red-700">
-                {{ props.error }}
-              </p>
-            </div>
-          </div>
-        </div>
+        <ErrorAlert v-if="props.error" :message="props.error" />
 
         <div class="mt-6 sm:mt-6 sm:flex sm:flex-row-reverse">
           <button
@@ -179,7 +168,8 @@ import type { RoleWithUsers } from '../types';
 import { useUsers } from '@/features/users/composables/useUsers';
 import { useRoles } from '@/features/roles/composables/useRoles';
 import type { User } from '@/features/users/types';
-import { PlusIcon, MagnifyingGlassIcon, UserGroupIcon, ExclamationTriangleIcon } from '@heroicons/vue/24/outline';
+import { PlusIcon, MagnifyingGlassIcon, UserGroupIcon } from '@heroicons/vue/24/outline';
+import ErrorAlert from '@/shared/components/ErrorAlert.vue';
 
 interface Props {
   isOpen: boolean;

--- a/src/features/roles/components/ConfirmDeleteModal.vue
+++ b/src/features/roles/components/ConfirmDeleteModal.vue
@@ -87,18 +87,7 @@
           </div>
         </div>
 
-        <div v-if="props.error" class="mt-4 p-4 bg-red-50 border border-red-200 rounded-md">
-          <div class="flex">
-            <div class="flex-shrink-0">
-              <ExclamationTriangleIcon class="h-5 w-5 text-red-400" />
-            </div>
-            <div class="ml-3">
-              <p class="text-sm text-red-700">
-                {{ props.error }}
-              </p>
-            </div>
-          </div>
-        </div>
+        <ErrorAlert v-if="props.error" :message="props.error" />
 
         <div class="mt-5 sm:mt-4 sm:flex sm:flex-row-reverse">
           <button
@@ -128,6 +117,7 @@ import { ref, computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import type { RoleWithUsers } from '../types';
 import { ExclamationTriangleIcon } from '@heroicons/vue/24/outline';
+import ErrorAlert from '@/shared/components/ErrorAlert.vue';
 
 interface Props {
   isOpen: boolean;

--- a/src/features/roles/components/RoleModal.vue
+++ b/src/features/roles/components/RoleModal.vue
@@ -34,18 +34,7 @@
           </div>
         </div>
 
-        <div v-if="props.error" class="mt-4 p-4 bg-red-50 border border-red-200 rounded-md">
-          <div class="flex">
-            <div class="flex-shrink-0">
-              <ExclamationTriangleIcon class="h-5 w-5 text-red-400" />
-            </div>
-            <div class="ml-3">
-              <p class="text-sm text-red-700">
-                {{ props.error }}
-              </p>
-            </div>
-          </div>
-        </div>
+        <ErrorAlert v-if="props.error" :message="props.error" />
 
         <form @submit.prevent="handleSubmit" class="mt-6">
           <div class="space-y-4">
@@ -116,7 +105,8 @@ import { ref, reactive, computed, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import type { RoleWithUsers, AdminRoleCreationDto } from '../types';
 import { useRolesStore } from '../store';
-import { ShieldCheckIcon, ExclamationTriangleIcon } from '@heroicons/vue/24/outline';
+import { ShieldCheckIcon } from '@heroicons/vue/24/outline';
+import ErrorAlert from '@/shared/components/ErrorAlert.vue';
 
 interface Props {
   isOpen: boolean;

--- a/src/shared/components/ErrorAlert.vue
+++ b/src/shared/components/ErrorAlert.vue
@@ -1,0 +1,18 @@
+<template>
+  <div v-if="message" class="mt-4 p-4 bg-red-50 border border-red-200 rounded-md">
+    <div class="flex">
+      <div class="flex-shrink-0">
+        <ExclamationTriangleIcon class="h-5 w-5 text-red-400" />
+      </div>
+      <div class="ml-3">
+        <p class="text-sm text-red-700">{{ message }}</p>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ExclamationTriangleIcon } from '@heroicons/vue/24/outline';
+
+defineProps<{ message?: string }>();
+</script>


### PR DESCRIPTION
## Summary
- create new `ErrorAlert` component for displaying error messages
- use `ErrorAlert` in role management modals

## Testing
- `pnpm test` *(fails: Error creating role, remove user)*

------
https://chatgpt.com/codex/tasks/task_b_68654cec4c88832dba05ed9b107a59f4