### PR TITLE
fix: rely only on isAdmin for role badge

### DIFF
--- a/src/features/users/components/UserTable.vue
+++ b/src/features/users/components/UserTable.vue
@@ -26,7 +26,7 @@ const getUserRoles = (user: User): Role[] => {
 };
 
 const getRoleBadgeClass = (role: Role) => {
-  return role.isAdmin || role.name === 'Admin'
+  return role.isAdmin
     ? 'bg-primary text-white'
     : 'bg-neutral-200 text-neutral-700';
 };


### PR DESCRIPTION
## Summary
- adjust `getRoleBadgeClass` to use `role.isAdmin` only

## Testing
- `pnpm lint` *(fails: 'err' unused in other files)*
- `pnpm test` *(fails: 2 failing tests in roles store)*

------
https://chatgpt.com/codex/tasks/task_b_68658827e1cc832dac18b9931ffe51d9