### PR TITLE
feat: add typed payload for role permissions update

### DIFF
--- a/src/features/auth/store.ts
+++ b/src/features/auth/store.ts
@@ -200,7 +200,7 @@ export const useAuthStore = defineStore('auth', () => {
       await getMe(storedToken);
       isAuthenticated.value = true;
       return true;
-    } catch (err: any) {
+    } catch {
       clearToken();
       localStorage.removeItem('twoFactorToken');
       token.value = null;

--- a/src/features/roles/api.ts
+++ b/src/features/roles/api.ts
@@ -7,6 +7,7 @@ import type {
   RoleError,
   User,
   AdminRoleCreationDto,
+  UpdateRolePermissionsPayload,
 } from './types';
 
 class RoleApiError extends Error {
@@ -266,7 +267,7 @@ export const getRolePermissions = async (roleId: string) => {
 export const updateRolePermissions = async (
   serverId: string,
   roleId: string,
-  payload: any,
+  payload: UpdateRolePermissionsPayload,
 ) => {
   try {
     if (!serverId.trim()) {

--- a/src/features/roles/types.ts
+++ b/src/features/roles/types.ts
@@ -10,6 +10,11 @@ export interface PermissionVmDto {
   bitmask: number;
 }
 
+export interface UpdateRolePermissionsPayload {
+  permissionServers: PermissionServerDto[];
+  permissionVms: PermissionVmDto[];
+}
+
 export interface Role {
   id: string;
   name: string;

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -181,7 +181,7 @@ router.beforeEach(async (to, from, next) => {
     if (hasToken && !hasUser) {
       try {
         await auth.fetchCurrentUser();
-      } catch (err) {
+      } catch {
         auth.resetAuthState();
         next('/login');
         return false;


### PR DESCRIPTION
## Summary
- define `UpdateRolePermissionsPayload` interface
- use it in `updateRolePermissions` API
- fix lint errors in auth store and router