### PR TITLE
fix/delete-modal loading

### DIFF
--- a/src/features/auth/store.ts
+++ b/src/features/auth/store.ts
@@ -57,11 +57,11 @@ export const useAuthStore = defineStore('auth', () => {
         setToken(token.value);
         await fetchCurrentUser();
       }
-    } catch (err: any) {
-      console.error('Login failed:', err);
+    } catch (_err: any) {
+      console.error('Login failed:', _err);
       throw new Error(
-        err.response?.data?.message ??
-          err.message ??
+        _err.response?.data?.message ??
+          _err.message ??
           i18n.global.t('errors.connection'),
       );
     }
@@ -200,7 +200,7 @@ export const useAuthStore = defineStore('auth', () => {
       await getMe(storedToken);
       isAuthenticated.value = true;
       return true;
-    } catch (err: any) {
+    } catch {
       clearToken();
       localStorage.removeItem('twoFactorToken');
       token.value = null;

--- a/src/features/roles/components/ConfirmDeleteModal.vue
+++ b/src/features/roles/components/ConfirmDeleteModal.vue
@@ -93,10 +93,9 @@
           <button
             type="button"
             @click="handleConfirm"
-            :disabled="!canDelete || loading"
+            :disabled="!canDelete"
             class="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-red-600 text-base font-medium text-white hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 sm:ml-3 sm:w-auto sm:text-sm disabled:opacity-50 disabled:cursor-not-allowed"
           >
-            <div v-if="loading" class="animate-spin -ml-1 mr-3 h-5 w-5 text-white border-2 border-white border-t-transparent rounded-full"></div>
             {{ t('roles.delete_role_title') }}
           </button>
           <button
@@ -133,7 +132,6 @@ interface Emits {
 const props = defineProps<Props>();
 const emit = defineEmits<Emits>();
 
-const loading = ref(false);
 const confirmText = ref('');
 
 const { t } = useI18n();
@@ -146,12 +144,7 @@ const canDelete = computed(() => {
 const handleConfirm = async () => {
   if (!canDelete.value) return;
   
-  loading.value = true;
-  try {
-    emit('confirm');
-  } finally {
-    loading.value = false;
-  }
+  emit('confirm');
 };
 
 const close = () => {

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -181,7 +181,7 @@ router.beforeEach(async (to, from, next) => {
     if (hasToken && !hasUser) {
       try {
         await auth.fetchCurrentUser();
-      } catch (err) {
+      } catch {
         auth.resetAuthState();
         next('/login');
         return false;


### PR DESCRIPTION
## Summary
- tidy up `ConfirmDeleteModal` by dropping unused loading state
- fix unused catch bindings to satisfy lint rules